### PR TITLE
feat: Add default resource limits #145

### DIFF
--- a/{{copier__project_slug}}/docs/development.md
+++ b/{{copier__project_slug}}/docs/development.md
@@ -69,3 +69,18 @@ To update the backend app dependencies, you must edit the `backend/requirements/
 Once you have made your changes, you need to regenerate the `backend/requirements/*.txt` files using:
 
        $ make compile
+
+
+## Resource Limits Consideration
+
+Resource limits have been predefined for both Django and NextJS services to ensure optimal performance and efficient resource utilization:
+
+- **Django**:
+  - Requests: `cpu: 200m`, `memory: 300Mi`
+  - Limits: `cpu: 250m`, `memory: 400Mi`
+
+- **NextJS**:
+  - Requests: `cpu: 100m`, `memory: 200Mi`
+  - Limits: `cpu: 250m`, `memory: 300Mi`
+
+Ensure these values are appropriate for your environment. If needed, adjust them based on real workload observations in a staging or production environment to balance performance and resource consumption.

--- a/{{copier__project_slug}}/k8s/base/django.yaml
+++ b/{{copier__project_slug}}/k8s/base/django.yaml
@@ -40,6 +40,13 @@ spec:
                 name: app-config
             - secretRef:
                 name: secrets-config
+          resources:
+            limits:
+              cpu: "250m"
+              memory: "400Mi"
+            requests:
+              cpu: "200m"
+              memory: "300Mi"
           livenessProbe:
             httpGet:
               path: /healthz

--- a/{{copier__project_slug}}/k8s/base/frontend.yaml
+++ b/{{copier__project_slug}}/k8s/base/frontend.yaml
@@ -36,11 +36,11 @@ spec:
               containerPort: 3000
           resources:
             limits:
-              cpu: "250m"
-              memory: "300Mi"
+              cpu: "500m"
+              memory: "600Mi"
             requests:
               cpu: "100m"
-              memory: "200Mi"
+              memory: "300Mi"
           env:
             - name: PORT
               value: "3000"

--- a/{{copier__project_slug}}/k8s/base/frontend.yaml
+++ b/{{copier__project_slug}}/k8s/base/frontend.yaml
@@ -34,6 +34,13 @@ spec:
           ports:
             - name: http-server
               containerPort: 3000
+          resources:
+            limits:
+              cpu: "250m"
+              memory: "300Mi"
+            requests:
+              cpu: "100m"
+              memory: "200Mi"
           env:
             - name: PORT
               value: "3000"


### PR DESCRIPTION
## :dart: What needed to be done and why?

Ticket: [#145](https://github.com/sixfeetup/scaf/issues/145)
Add default resource limits to kubernetes for django and nextjs

*Quick summary of the issue*
Needed to add default resource limits to kubernetes django and frontend deployment

## :new: What is changed by this PR?

Added default resources for both django and frontend deployment

## :clipboard: Code Review Cheatsheet

<details>

<summary>What the reviewer should check</summary>

| Check  | Description |
| ------------- | ------------- |
| :truck: **Diff size** | Is the PR small and focused, or should it be broken into smaller PRs?
| :test_tube: **Unit tests** | Are new features covered with appropriate unit tests?
| :lab_coat: **Acceptance Criteria met** | Are the Acceptance Criteria listed in the issue met?
| :monocle_face: **Code clarity** | Is the code easy to understand? Are variable and function names meaningful?
| :jigsaw: **Code organization** | Are files, modules, and functions structured logically?
| :carpentry_saw: **Conciseness** | Is the code free of unnecessary complexity or redundant code?
| :speech_balloon: **Comments & documentation** | Are code comments explaining *why* and not *how*? Is the documentation up-to-date?
| :abacus: **Code consistency** | Does the code follow existing patterns and conventions in the project?
| :biohazard: **Function length** | Are functions too long? Should they be broken into smaller, more focused functions?
| :radioactive: **Class design** | Are classes well-structured and not overly large or doing too much?
| :paw_prints: **Logging and debugging statements** | Are print/debug statements removed or replaced with proper logging?

</details>
