### PR TITLE
feat: Use project-specific names for Postgres PVCs #304

### DIFF
--- a/{{copier__project_slug}}/k8s/local/postgres.yaml
+++ b/{{copier__project_slug}}/k8s/local/postgres.yaml
@@ -39,7 +39,7 @@ spec:
           - secretRef:
               name: secrets-config
           volumeMounts:
-            - name: postgres-volume-mount
+            - name: {{ copier__project_dash }}-postgres-volume-mount
               mountPath: /var/lib/postgresql/data
           # readinessProbe:
           #   exec:
@@ -58,16 +58,16 @@ spec:
           #   initialDelaySeconds: 15
           #   timeoutSeconds: 2
       volumes:
-        - name: postgres-volume-mount
+        - name: {{ copier__project_dash }}-postgres-volume-mount
           persistentVolumeClaim:
-            claimName: postgres-pvc
+            claimName: {{ copier__project_dash }}-postgres-pvc
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   annotations:
     tilt.dev/down-policy: keep
-  name: postgres-pvc
+  name: {{ copier__project_dash }}-postgres-pvc
   labels:
     type: local
 spec:


### PR DESCRIPTION
## :dart: What needed to be done and why?

Ticket: [#304](https://github.com/sixfeetup/scaf/issues/304)
Use project-specific names for Postgres PVCs

Currently, if a user has multiple scaffolded projects, each project ends up using the same PostgreSQL PersistentVolumeClaim (PVC) name. This leads to conflicts and potential issues when deploying multiple projects in the same cluster.

## :new: What is changed by this PR?

PostgreSQL PersistentVolumeClaims (PVCs) are now uniquely named per project, avoiding conflicts when deploying multiple scaffolded projects in the same cluster. This ensures isolation, scalability, and smooth deployments.

## :clipboard: Code Review Cheatsheet

<details>

<summary>What the reviewer should check</summary>

| Check  | Description |
| ------------- | ------------- |
| :truck: **Diff size** | Is the PR small and focused, or should it be broken into smaller PRs?
| :test_tube: **Unit tests** | Are new features covered with appropriate unit tests?
| :lab_coat: **Acceptance Criteria met** | Are the Acceptance Criteria listed in the issue met?
| :monocle_face: **Code clarity** | Is the code easy to understand? Are variable and function names meaningful?
| :jigsaw: **Code organization** | Are files, modules, and functions structured logically?
| :carpentry_saw: **Conciseness** | Is the code free of unnecessary complexity or redundant code?
| :speech_balloon: **Comments & documentation** | Are code comments explaining *why* and not *how*? Is the documentation up-to-date?
| :abacus: **Code consistency** | Does the code follow existing patterns and conventions in the project?
| :biohazard: **Function length** | Are functions too long? Should they be broken into smaller, more focused functions?
| :radioactive: **Class design** | Are classes well-structured and not overly large or doing too much?
| :paw_prints: **Logging and debugging statements** | Are print/debug statements removed or replaced with proper logging?

</details>
