### PR TITLE
feat: hide aws option at bootstraping

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -111,19 +111,13 @@ copier__aws_region:
   type: str
   default: "us-east-1"
   help: "AWS region for deployment."
-  validator: >-
-    {% if not copier__aws_region.strip() %}
-      "AWS region cannot be empty."
-    {% endif %}
+  when: false
 
 copier__aws_account_id:
   type: str
   default: "000000000000"
   help: "AWS account ID for deployment."
-  validator: >-
-    {% if not copier__aws_account_id.strip() %}
-      "AWS account ID cannot be empty."
-    {% endif %}
+  when: false
 
 copier__create_nextjs_frontend:
   type: bool


### PR DESCRIPTION
## :dart: What needed to be done and why?

Ticket: https://github.com/sixfeetup/scaf-fullstack-template/issues/9

this change let's copier setup the default aws options (region us-east-1 and account id 000000000000) in all config files, so that they can be changed at any point in future