### PR TITLE
feat: Strip machine-read fields in project name

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -16,14 +16,19 @@ _exclude:
   - ".svn"
   - "*.test-data.yml"
 
-copier__project_name:
+copier__project_name_raw:
   type: str
   default: "My Awesome Scaf Project"
   help: "The name of your project."
   validator: >-
-    {% if not copier__project_name.strip() %}
+    {% if not copier__project_name_raw.strip() %}
       "Project name cannot be empty."
     {% endif %}
+
+copier__project_name:
+  type: str
+  default: "{{ copier__project_name_raw | replace(\"'\", \"\") | replace('\"', '') }}"
+  when: false
 
 copier__project_slug:
   type: str

--- a/nextjs-django-github.test-data.yml
+++ b/nextjs-django-github.test-data.yml
@@ -8,7 +8,7 @@ copier__email: iamscafman@sixfeetup.com
 copier__mail_service: Amazon SES
 copier__operating_system: k3s
 copier__project_dash: my-awesome-scaf-project
-copier__project_name: My Awesome Scaf ProjectXXX
+copier__project_name_raw: My Awesome Scaf ProjectXXX
 copier__project_slug: my_awesome_scaf_project
 copier__repo_name: my_awesome_scaf_project
 copier__repo_url: git@github.com:sixfeetup/my_awesome_scaf_project.git


### PR DESCRIPTION
## :dart: What needed to be done and why?

Ticket: #174
Issue with project names and pre-existing projects [#174](https://github.com/sixfeetup/scaf/issues/174)

Project name was not sanitized if there were any quote or apostrophe in the project name.

## :new: What is changed by this PR?

Update copier.yaml file so that the project name is always sanitized and quote or apostrophe are removed from the project name.

## :clipboard: Code Review Cheatsheet

<details>

<summary>What the reviewer should check</summary>

| Check  | Description |
| ------------- | ------------- |
| :truck: **Diff size** | Is the PR small and focused, or should it be broken into smaller PRs?
| :test_tube: **Unit tests** | Are new features covered with appropriate unit tests?
| :lab_coat: **Acceptance Criteria met** | Are the Acceptance Criteria listed in the issue met?
| :monocle_face: **Code clarity** | Is the code easy to understand? Are variable and function names meaningful?
| :jigsaw: **Code organization** | Are files, modules, and functions structured logically?
| :carpentry_saw: **Conciseness** | Is the code free of unnecessary complexity or redundant code?
| :speech_balloon: **Comments & documentation** | Are code comments explaining *why* and not *how*? Is the documentation up-to-date?
| :abacus: **Code consistency** | Does the code follow existing patterns and conventions in the project?
| :biohazard: **Function length** | Are functions too long? Should they be broken into smaller, more focused functions?
| :radioactive: **Class design** | Are classes well-structured and not overly large or doing too much?
| :paw_prints: **Logging and debugging statements** | Are print/debug statements removed or replaced with proper logging?

</details>
