### PR TITLE
feat: add the template to get .copier-answers.yaml

### DIFF
--- a/{{_copier_conf.answers_file}}.jinja
+++ b/{{_copier_conf.answers_file}}.jinja
@@ -1,0 +1,2 @@
+# Changes here will be overwritten by Copier
+{{ _copier_answers|to_nice_yaml -}}


### PR DESCRIPTION
## :dart: What needed to be done and why?

To be able to run copier to update a scaf projects with the latest changes in its original scaf template, one needs the [`.copier-answers.yaml` file](https://copier.readthedocs.io/en/stable/updating/).
However this file is not created unless a template tells copier to create it.
See the [minimal example](https://copier.readthedocs.io/en/stable/creating/#minimal-example) for this template.

## :new: What is changed by this PR?

Add the `.copier-answers.yaml` template.

## :clipboard: Code Review Cheatsheet

<details>

<summary>What the reviewer should check</summary>

| Check  | Description |
| ------------- | ------------- |
| :truck: **Diff size** | Is the PR small and focused, or should it be broken into smaller PRs?
| :test_tube: **Unit tests** | Are new features covered with appropriate unit tests?
| :lab_coat: **Acceptance Criteria met** | Are the Acceptance Criteria listed in the issue met?
| :monocle_face: **Code clarity** | Is the code easy to understand? Are variable and function names meaningful?
| :jigsaw: **Code organization** | Are files, modules, and functions structured logically?
| :carpentry_saw: **Conciseness** | Is the code free of unnecessary complexity or redundant code?
| :speech_balloon: **Comments & documentation** | Are code comments explaining *why* and not *how*? Is the documentation up-to-date?
| :abacus: **Code consistency** | Does the code follow existing patterns and conventions in the project?
| :biohazard: **Function length** | Are functions too long? Should they be broken into smaller, more focused functions?
| :radioactive: **Class design** | Are classes well-structured and not overly large or doing too much?
| :paw_prints: **Logging and debugging statements** | Are print/debug statements removed or replaced with proper logging?

</details>
