### PR TITLE
fix: bootstrap frontend deps with node user

### DIFF
--- a/{{copier__project_slug}}/Makefile
+++ b/{{copier__project_slug}}/Makefile
@@ -117,12 +117,12 @@ compile: backend/requirements/base.in backend/requirements/tests.in ## compile l
 		 uv pip compile --upgrade --output-file /local/local.txt /local/local.in"
 
 compile-frontend: frontend/package.json ## compile latest frontend dependencies to be built into the docker image
-	@docker run --rm -w "/app" -v $(shell pwd)/frontend:/app node:lts /bin/bash -c "npm install"
+	@docker run --rm --user node -w "/app" -v $(shell pwd)/frontend:/app node:lts /bin/bash -c "npm install"
 
 init-frontend-dependencies: ## compile initial frontend dependencies to be built into the docker image
-	@docker run --rm -w "/app" -v $(shell pwd)/frontend:/app node:lts /bin/bash -c \
+	@docker run --rm --user node -w "/app" -v $(shell pwd)/frontend:/app node:lts /bin/bash -c \
 		"xargs npm install < dependencies-init.txt"
-	@docker run --rm -w "/app" -v $(shell pwd)/frontend:/app node:lts /bin/bash -c \
+	@docker run --rm --user node -w "/app" -v $(shell pwd)/frontend:/app node:lts /bin/bash -c \
 		"xargs npm install --save-dev < dependencies-dev-init.txt"
 
 shell-backend:  ## Shell into the running Django container


### PR DESCRIPTION
## :dart: What needed to be done and why?

Fix frontend deps permission error:
```
  File "/nix/store/lhpwdis5hkyljz1d200bj1s6g51ljq9k-python3-3.12.8/lib/python3.12/shutil.py", line 703, in _rmtree_safe_fd
    onexc(func, path, err)
  File "/nix/store/lhpwdis5hkyljz1d200bj1s6g51ljq9k-python3-3.12.8/lib/python3.12/shutil.py", line 700, in _rmtree_safe_fd
    onexc(os.unlink, fullname, err)
  File "/nix/store/lhpwdis5hkyljz1d200bj1s6g51ljq9k-python3-3.12.8/lib/python3.12/shutil.py", line 698, in _rmtree_safe_fd
    os.unlink(entry.name, dir_fd=topfd)
PermissionError: [Errno 13] Permission denied: '/home/roche/projects/scaf-test-copier/test-project/my_awesome_scaf_project/frontend/node_modules'
```

## :new: What is changed by this PR?

Add `--user node` flag to docker run command to ensure local user maps to node user.