### PR TITLE
chore: fix for aws key pair naming error (#85)

### DIFF
--- a/{{copier__project_slug}}/bootstrap-cluster/k3s.yaml
+++ b/{{copier__project_slug}}/bootstrap-cluster/k3s.yaml
@@ -157,7 +157,7 @@ tasks:
         fi
         scp -o StrictHostKeyChecking=no -i {{ '{{.SSH_KEY}}' }} ubuntu@{{ '{{.IP}}' }}:/etc/rancher/k3s/k3s.yaml {{ '{{.ENV}}' }}/kubeconfig
       - sed -i'' -e "s/127.0.0.1/{{ '{{.IP}}' }}/g" {{ '{{.ENV}}' }}/kubeconfig
-      - sed -i'' -e "s/default/hotelnames-{{ '{{.ENV}}' }}/g" {{ '{{.ENV}}' }}/kubeconfig
+      - sed -i'' -e "s/default/{{copier__project_slug}}-{{ '{{.ENV}}' }}/g" {{ '{{.ENV}}' }}/kubeconfig
       - chmod 600 {{ '{{.ENV}}' }}/kubeconfig
 
   store-kubeconfig:

--- a/{{copier__project_slug}}/terraform/modules/base/ec2.tf
+++ b/{{copier__project_slug}}/terraform/modules/base/ec2.tf
@@ -24,7 +24,7 @@ resource "tls_private_key" "deploy_key" {
 }
 
 resource "aws_key_pair" "default_key" {
-  key_name   = "hotelnames_deploy_key"
+  key_name   = "{{ copier__project_slug }}_deploy_key"
   public_key = tls_private_key.deploy_key.public_key_openssh
 }
 


### PR DESCRIPTION
## :dart: What needed to be done and why?

Ticket: #85
Key Pair names were from a project and weren't generated based on the project slug, therefore not unique if more than one project was built in an aws subaccount.

## :new: What is changed by this PR?

Uses the project slug in the name.

## :clipboard: Code Review Cheatsheet

<details>

<summary>What the reviewer should check</summary>

| Check  | Description |
| ------------- | ------------- |
| :truck: **Diff size** | Is the PR small and focused, or should it be broken into smaller PRs?
| :test_tube: **Unit tests** | Are new features covered with appropriate unit tests?
| :lab_coat: **Acceptance Criteria met** | Are the Acceptance Criteria listed in the issue met?
| :monocle_face: **Code clarity** | Is the code easy to understand? Are variable and function names meaningful?
| :jigsaw: **Code organization** | Are files, modules, and functions structured logically?
| :carpentry_saw: **Conciseness** | Is the code free of unnecessary complexity or redundant code?
| :speech_balloon: **Comments & documentation** | Are code comments explaining *why* and not *how*? Is the documentation up-to-date?
| :abacus: **Code consistency** | Does the code follow existing patterns and conventions in the project?
| :biohazard: **Function length** | Are functions too long? Should they be broken into smaller, more focused functions?
| :radioactive: **Class design** | Are classes well-structured and not overly large or doing too much?
| :paw_prints: **Logging and debugging statements** | Are print/debug statements removed or replaced with proper logging?

</details>
