### PR TITLE
fix: exclude github workflow, README.md and scaf logo

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -15,6 +15,10 @@ _exclude:
   - ".DS_Store"
   - ".svn"
   - "*.test-data.yml"
+  - "README.md"
+  - "scaf-logo.png"
+  - ".github/workflows/semantic-pull-request.yaml"
+  - ".github/workflows/semantic-release.yaml"
 
 copier__project_name_raw:
   type: str


### PR DESCRIPTION
Exclude files that don't belong in the final rendered version of the template. Fixes #106 