### PR TITLE
fix: set default CORS_ALLOWED_ORIGINS to []

### DIFF
--- a/{{copier__project_slug}}/backend/config/settings/production.py
+++ b/{{copier__project_slug}}/backend/config/settings/production.py
@@ -185,7 +185,7 @@ LOGGING = {
 {%- if copier__create_nextjs_frontend %}
 # ------------------------------------------------------------------------------
 # CORS settings
-CORS_ALLOWED_ORIGINS = env.list("CORS_ALLOWED_ORIGINS")
+CORS_ALLOWED_ORIGINS = env.list("CORS_ALLOWED_ORIGINS", default=[])
 {%- endif %}
 
 # Your stuff...


### PR DESCRIPTION
## :dart: What needed to be done and why?

sets a default CORS_ALLOWED_ORIGINS to avoid breaking with KeyError