### PR TITLE
set prod letsencrypt to sandbox

### DIFF
--- a/{{copier__project_slug}}/k8s/sandbox/certificate.yaml
+++ b/{{copier__project_slug}}/k8s/sandbox/certificate.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   secretName: cluster-cert-tls
   issuerRef:
-    name: letsencrypt-staging
+    name: letsencrypt-prod
     kind: ClusterIssuer
   dnsNames:
     - api.sandbox.{{ copier__domain_name }}


### PR DESCRIPTION
## :dart: What needed to be done and why?

So that Cloudfront serves correctly the frontend