### PR TITLE
Hillairet/update ruff in pre commit

### DIFF
--- a/template/.pre-commit-config.yaml
+++ b/template/.pre-commit-config.yaml
@@ -2,33 +2,34 @@ repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0
     hooks:
-    -   id: check-case-conflict
-    -   id: check-merge-conflict
-    -   id: debug-statements
+      - id: check-case-conflict
+      - id: check-merge-conflict
+      - id: debug-statements
         exclude: ^backend/{{ copier__project_slug }}/utils/debugger.py
-    -   id: detect-aws-credentials
+      - id: detect-aws-credentials
         args: ["--allow-missing-credentials"]
-    -   id: detect-private-key
+      - id: detect-private-key
 
   - repo: https://github.com/psf/black
     rev: 23.9.1
     hooks:
-    -   id: black
+      - id: black
 
   - repo: https://github.com/pycqa/isort
     rev: 5.12.0
     hooks:
-    -   id: isort
+      - id: isort
         args: ["--profile", "black", "--filter-files"]
 
-  - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: 'v0.0.290'
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.12.8
     hooks:
-    -   id: ruff
+      # Run the linter.
+      - id: ruff-check
         args: ["--ignore", "E501"]
 
   - repo: https://github.com/PyCQA/bandit
     rev: 1.7.5
     hooks:
-    -   id: bandit
+      - id: bandit
         args: ["-ll"]

--- a/template/.pre-commit-config.yaml
+++ b/template/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
     hooks:
       # Run the linter.
       - id: ruff-check
-        args: ["--ignore", "E501"]
+        args: ["--ignore", "E501", "--extend-select", "E,W"]
 
   - repo: https://github.com/PyCQA/bandit
     rev: 1.7.5


### PR DESCRIPTION
## :dart: What needed to be done and why?

I noticed that the ruff pre-commit was pointing to the old repo org and seemed quite out of date. So I updated it.

In the process, I noticed that we may not be matching the flake8 checks that I believe ruff was supposed to replace.
According to the [configuration docs here](https://docs.astral.sh/ruff/configuration/), only a few "E" and all the "F" rules are in the default config, but not the "W" and not the Macabe stuff that are default in flake8.
I just added all the "E" and "W" rules.

I tested on a freshly generated project and these new ruff rules pass successfully.

## :new: What is changed by this PR?

* Switch to new repo location and latest version for pre-commit ruff
* Extend the list of rules to include "W" and all "E" except the one excluded.

## :clipboard: Code Review Cheatsheet

<details>

<summary>What the reviewer should check</summary>

| Check  | Description |
| ------------- | ------------- |
| :truck: **Diff size** | Is the PR small and focused, or should it be broken into smaller PRs?
| :test_tube: **Unit tests** | Are new features covered with appropriate unit tests?
| :lab_coat: **Acceptance Criteria met** | Are the Acceptance Criteria listed in the issue met?
| :monocle_face: **Code clarity** | Is the code easy to understand? Are variable and function names meaningful?
| :jigsaw: **Code organization** | Are files, modules, and functions structured logically?
| :carpentry_saw: **Conciseness** | Is the code free of unnecessary complexity or redundant code?
| :speech_balloon: **Comments & documentation** | Are code comments explaining *why* and not *how*? Is the documentation up-to-date?
| :abacus: **Code consistency** | Does the code follow existing patterns and conventions in the project?
| :biohazard: **Function length** | Are functions too long? Should they be broken into smaller, more focused functions?
| :radioactive: **Class design** | Are classes well-structured and not overly large or doing too much?
| :paw_prints: **Logging and debugging statements** | Are print/debug statements removed or replaced with proper logging?

</details>
