### PR TITLE
fix: update Dockerfile to run on Debian trixie

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -107,7 +107,7 @@ copier__version:
 
 copier__timezone:
   type: str
-  default: "US/Eastern"
+  default: "America/New_York"
   help: "The default timezone for the project."
   validator: >-
     {% if not copier__timezone.strip() %}

--- a/template/Makefile
+++ b/template/Makefile
@@ -107,7 +107,7 @@ pipdeptree: ## Show the dependencies of installed packages as a tree structure
 	$(KUBECTL_EXEC_BACKEND) -c "uv pip tree --no-cache"
 
 compile: backend/requirements/base.in backend/requirements/tests.in ## compile latest requirements to be built into the docker image
-	@docker run --rm -v $(shell pwd)/backend/requirements:/local python:3.12-slim /bin/bash -c \
+	@docker run --rm -v $(shell pwd)/backend/requirements:/local python:3.13-slim /bin/bash -c \
 		"apt-get update; apt-get install -y libpq-dev; \
 		 pip install uv; \
 		 touch /local/base.txt; touch /local/production.txt; touch /local/tests.txt; touch /local/local.txt; \

--- a/template/backend/Dockerfile
+++ b/template/backend/Dockerfile
@@ -1,5 +1,5 @@
 # Build all of the dependencies then we will build the actual application image
-FROM python:3.13.6-slim-trixie AS build
+FROM python:3.13-slim AS build
 
 ENV PYTHONUNBUFFERED=1
 ENV PYTHONDONTWRITEBYTECODE=1
@@ -16,14 +16,11 @@ RUN apt-get update \
     gettext \
     gnupg \
     && mkdir -p /etc/apt/keyrings \
-    && curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc -o /etc/apt/keyrings/postgresql.asc \
-    && echo "deb [signed-by=/etc/apt/keyrings/postgresql.asc] http://apt.postgresql.org/pub/repos/apt trixie-pgdg main" > /etc/apt/sources.list.d/pgdg.list \
-    && apt-get update \
     && apt-get install --no-install-recommends -y \
     libffi-dev \
     libpq-dev \
     libssl-dev \
-    postgresql-client-16 \
+    postgresql-client \
     postgresql-client-common
 
 
@@ -57,7 +54,7 @@ RUN set -x \
     -r /tmp/requirements/tests.txt; fi
 
 # Now we can build the application image
-FROM python:3.13.6-slim-trixie
+FROM python:3.13-slim
 
 ENV PYTHONUNBUFFERED=1
 ENV PYTHONPATH="/app"
@@ -85,11 +82,8 @@ RUN apt-get update \
     libpq5 \
     gnupg \
     && mkdir -p /etc/apt/keyrings \
-    && curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc -o /etc/apt/keyrings/postgresql.asc \
-    && echo "deb [signed-by=/etc/apt/keyrings/postgresql.asc] http://apt.postgresql.org/pub/repos/apt trixie-pgdg main" > /etc/apt/sources.list.d/pgdg.list \
-    && apt-get update \
     && apt-get install --no-install-recommends -y \
-    $(if [ "$DEVEL" = "yes" ]; then echo 'bash postgresql-client-16'; fi) \
+    $(if [ "$DEVEL" = "yes" ]; then echo 'bash postgresql-client'; fi) \
     # awscli
     && apt-get install -y \
     awscli \

--- a/template/backend/Dockerfile
+++ b/template/backend/Dockerfile
@@ -1,5 +1,5 @@
 # Build all of the dependencies then we will build the actual application image
-FROM python:3-slim AS build
+FROM python:3.13.6-slim-trixie AS build
 
 ENV PYTHONUNBUFFERED=1
 ENV PYTHONDONTWRITEBYTECODE=1
@@ -15,8 +15,9 @@ RUN apt-get update \
     curl \
     gettext \
     gnupg \
-    && curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
-    && echo "deb http://apt.postgresql.org/pub/repos/apt bookworm-pgdg main" > /etc/apt/sources.list.d/pgdg.list \
+    && mkdir -p /etc/apt/keyrings \
+    && curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc -o /etc/apt/keyrings/postgresql.asc \
+    && echo "deb [signed-by=/etc/apt/keyrings/postgresql.asc] http://apt.postgresql.org/pub/repos/apt trixie-pgdg main" > /etc/apt/sources.list.d/pgdg.list \
     && apt-get update \
     && apt-get install --no-install-recommends -y \
     libffi-dev \
@@ -56,7 +57,7 @@ RUN set -x \
     -r /tmp/requirements/tests.txt; fi
 
 # Now we can build the application image
-FROM python:3-slim
+FROM python:3.13.6-slim-trixie
 
 ENV PYTHONUNBUFFERED=1
 ENV PYTHONPATH="/app"
@@ -81,12 +82,13 @@ RUN apt-get update \
     ca-certificates \
     curl \
     gettext \
+    libpq5 \
     gnupg \
-    && curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
-    && echo "deb http://apt.postgresql.org/pub/repos/apt bookworm-pgdg main" > /etc/apt/sources.list.d/pgdg.list \
+    && mkdir -p /etc/apt/keyrings \
+    && curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc -o /etc/apt/keyrings/postgresql.asc \
+    && echo "deb [signed-by=/etc/apt/keyrings/postgresql.asc] http://apt.postgresql.org/pub/repos/apt trixie-pgdg main" > /etc/apt/sources.list.d/pgdg.list \
     && apt-get update \
     && apt-get install --no-install-recommends -y \
-    libpq5 \
     $(if [ "$DEVEL" = "yes" ]; then echo 'bash postgresql-client-16'; fi) \
     # awscli
     && apt-get install -y \


### PR DESCRIPTION
## :dart: What needed to be done and why?

backend's Dockerfile breaks while trying to get the dependencies for postgresql-client-16. This PR pins the python version to `python:3.13.6-slim-trixie`

Also I had to change the TIME_ZONE because otherwise it complains with `[backend-migration] ValueError: Incorrect timezone setting: US/Eastern`

Consider the following: 

- [ ] update to python 3.14 ? I didn't use it because the previous Dockerfile was using 3-slim, which was using python 3.13 bookworm.
- [ ] consider just specifying postgresql-client since for Debian trixie it uses version 17. Thus we don't have to specify postgresq-client-16 , and also don't have to bring the extra repository settings