### PR TITLE
feat: add support for personal .envrc.local environment files

### DIFF
--- a/template/.envrc
+++ b/template/.envrc
@@ -1,5 +1,11 @@
 #!/use/bin/env bash
 
+# Source personal .envrc.local if it exists
+if [ -f .envrc.local ]; then
+    echo "Loading personal environment from .envrc.local"
+    source .envrc.local
+fi
+
 if command -v nix-shell >/dev/null 2>&1; then
     use flake
 fi

--- a/template/.gitignore
+++ b/template/.gitignore
@@ -53,6 +53,7 @@ docker-compose.override.yml
 
 # Environment files
 env
+.envrc.local
 
 # vs code
 .vscode/

--- a/template/docs/development.md
+++ b/template/docs/development.md
@@ -20,6 +20,17 @@ Consult the links below if you prefer to use Minikube or Docker Desktop instead:
 
 2. Prepare the environment variables. Edit the `.envrc` file to work for your environment.
 
+   **For personal environment configurations**: Create a `.envrc.local` file for your personal development settings that won't be committed to version control:
+
+   ```bash
+   # Example .envrc.local file
+   export DEBUG=true
+   export LOG_LEVEL=debug
+   export LOCAL_DEV_SETTING=custom_value
+   ```
+
+   The `.envrc.local` file will be automatically loaded when you enter the directory (after `.envrc`), allowing you to override or add environment variables without modifying the shared `.envrc` file.
+
 ## Run the kubernetes cluster and the {{ copier__project_slug }} app to develop the code
 
 First load the environment variables, then run:


### PR DESCRIPTION
## Summary
- Add automatic sourcing of `.envrc.local` files in the main `.envrc` script
- Add `.envrc.local` to `.gitignore` to prevent accidental commits
- Document the new feature in `docs/development.md` with usage examples

## Test plan
- [ ] Verify that `.envrc` sources `.envrc.local` when it exists
- [ ] Confirm that `.envrc.local` files are ignored by git
- [ ] Test that environment variables in `.envrc.local` override/extend those in `.envrc`
- [ ] Ensure the feature works correctly when `.envrc.local` doesn't exist

## Why this is useful
This enhancement allows developers to:
- Create personal environment configurations without modifying the shared `.envrc` file
- Override default settings for their local development needs
- Keep sensitive or personal configurations out of version control
- Avoid merge conflicts in environment configuration files

🤖 Generated with [Claude Code](https://claude.ai/code)