### PR TITLE
chore(pre-commit): remove detect-aws-credentials

### DIFF
--- a/template/.pre-commit-config.yaml
+++ b/template/.pre-commit-config.yaml
@@ -6,8 +6,6 @@ repos:
   - id: check-merge-conflict
   - id: debug-statements
     exclude: ^backend/{{ copier__project_slug }}/utils/debugger.py
-  - id: detect-aws-credentials
-    args: ["--allow-missing-credentials"]
   - id: detect-private-key
 
 - repo: https://github.com/psf/black


### PR DESCRIPTION
`detect-aws-credentials` is reporting false positives and breaking CI on all new projects
