### PR TITLE
chore(frontend): pin apollo to 3.14

### DIFF
--- a/template/frontend/dependencies-init.txt
+++ b/template/frontend/dependencies-init.txt
@@ -1,4 +1,4 @@
-@apollo/client
+@apollo/client@3.14
 @testing-library/jest-dom
 @testing-library/user-event
 @typescript-eslint/eslint-plugin


### PR DESCRIPTION
PR to pin `@apollo/client` to 3.14 until we migrate the frontend app to v4.